### PR TITLE
79 unify results in a single output file2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.3
+- Implemented unified output file (solution.xdmf) containing all simulation fields.
+
 ## 3.0.2
 - Refactored MaterialProps.py by moving classes into individual files in ConstitutiveModels folder.
 - Import automation of files in ConstitutiveModels so that the only step to add a new constitutive model is to include the file in the folder.

--- a/safeincave/OutputHandler.py
+++ b/safeincave/OutputHandler.py
@@ -58,6 +58,7 @@ class SaveFields:
         self.eq = eq
         self.fields_data = []
         self.output_fields = []
+        self.merged_output = None
 
     def set_output_folder(self, output_folder: str) -> None:
         """
@@ -136,9 +137,58 @@ class SaveFields:
             output_field.write_mesh(self.eq.grid.mesh)
             self.output_fields.append(output_field)
 
+        # Create merged solution file containing all fields
+        # IMPORTANT: Known limitations and behaviors of this merged XDMF file:
+        #
+        # 1. VTK COMPOSITE METADATA (Artifacts)
+        #    When multiple <Attribute> elements exist in the same XDMF <Grid>,
+        #    VTK interprets this as a composite dataset and AUTOMATICALLY ADDS:
+        #    - vtkCompositeIndex: Internal tracking field (not real data)
+        #    - vtkBlockColors: Internal visualization field (not real data)
+        #    These clutter the ParaView field list but are harmless. To hide them:
+        #    Right-click field name in ParaView → Hide
+        #
+        # 2. WRAP BY VECTOR FILTER FAILURE (Critical Limitation)
+        #    ParaView's "Wrap by Vector" filter (for mesh deformation visualization)
+        #    FAILS or BEHAVES INCORRECTLY when multiple vector fields are present.
+        #    ROOT CAUSE: Filter input selection is ambiguous with composite metadata.
+        #    WORKAROUND: Use individual field files instead:
+        #    - output_folder/u/u.xdmf for displacement deformation
+        #    Do NOT use this merged file for deformation visualization.
+        #
+        # 3. XDMF STRUCTURE LIMITATION (DOLFINx API)
+        #    DOLFINx's XDMFFile does not support external mesh references.
+        #    Result: Mesh geometry/topology is DUPLICATED in this file.
+        #    Impact: Larger file size (minor for most simulations).
+        #    Workaround: None; inherent to DOLFINx API design.
+        #
+        # 4. USE CASES FOR MERGED vs INDIVIDUAL FILES
+        #    USE MERGED (solution.xdmf) FOR:
+        #    - Post-processing analysis across all fields simultaneously
+        #    - Correlation studies between fields
+        #    - Statistical analysis and data export
+        #    - Quick initial result verification
+        #
+        #    USE INDIVIDUAL FILES FOR:
+        #    - Mesh deformation visualization (Wrap by Vector) → u/u.xdmf
+        #    - Field-specific analysis and filtering
+        #    - Publication-quality visualizations
+        #    - Large simulations (smaller file size per field)
+        #
+        merged_path = os.path.join(self.output_folder, "solution", "solution.xdmf")
+        os.makedirs(os.path.dirname(merged_path), exist_ok=True)
+        self.merged_output = do.io.XDMFFile(
+            self.eq.grid.mesh.comm,
+            merged_path,
+            "w",
+        )
+        self.merged_output.write_mesh(self.eq.grid.mesh)
+
     def save_fields(self, t: float) -> None:
         """
         Write all registered fields at simulation time ``t``.
+
+        Writes to BOTH individual field files AND the merged solution file.
 
         Parameters
         ----------
@@ -153,13 +203,18 @@ class SaveFields:
         -----
         For each descriptor in :attr:`fields_data`:
         1. Fetches the field via ``getattr(self.eq, field_name)``.
-        2. Sets ``field.name = label_name``.
-        3. Calls ``XDMFFile.write_function(field, t)`` on the corresponding writer.
+        2. Sets ``field.name = label_name`` (used in visualization).
+        3. Calls ``XDMFFile.write_function(field, t)`` on individual writer.
+        4. Calls ``XDMFFile.write_function(field, t)`` on merged solution writer.
         """
         for i, field_data in enumerate(self.fields_data):
             field = getattr(self.eq, field_data["field_name"])
             field.name = field_data["label_name"]
             self.output_fields[i].write_function(field, t)
+            # Write to merged solution file for unified analysis across all fields.
+            # For specific field visualization (e.g., deformation via Wrap by Vector),
+            # use individual field files in ParaView instead.
+            self.merged_output.write_function(field, t)
 
     def save_mesh(self) -> None:
         """

--- a/safeincave/OutputHandler.py
+++ b/safeincave/OutputHandler.py
@@ -145,16 +145,12 @@ class SaveFields:
         #    VTK interprets this as a composite dataset and AUTOMATICALLY ADDS:
         #    - vtkCompositeIndex: Internal tracking field (not real data)
         #    - vtkBlockColors: Internal visualization field (not real data)
-        #    These clutter the ParaView field list but are harmless. To hide them:
-        #    Right-click field name in ParaView → Hide
+        #    These clutter the ParaView field list but are harmless.
         #
         # 2. WARP BY VECTOR FILTER FAILURE (Critical Limitation)
         #    ParaView's "Warp by Vector" filter (for mesh deformation visualization)
         #    FAILS or BEHAVES INCORRECTLY when multiple vector fields are present.
         #    ROOT CAUSE: Filter input selection is ambiguous with composite metadata.
-        #    WORKAROUND: Use individual field files instead:
-        #    - output_folder/u/u.xdmf for displacement deformation
-        #    Do NOT use this merged file for deformation visualization.
         #
         # 3. XDMF STRUCTURE LIMITATION (DOLFINx API)
         #    DOLFINx's XDMFFile does not support external mesh references.
@@ -163,6 +159,7 @@ class SaveFields:
         #    Workaround: None; inherent to DOLFINx API design.
         #
         # 4. USE CASES FOR MERGED vs INDIVIDUAL FILES
+        #
         #    USE MERGED (solution.xdmf) FOR:
         #    - Post-processing analysis across all fields simultaneously
         #    - Correlation studies between fields

--- a/safeincave/OutputHandler.py
+++ b/safeincave/OutputHandler.py
@@ -148,8 +148,8 @@ class SaveFields:
         #    These clutter the ParaView field list but are harmless. To hide them:
         #    Right-click field name in ParaView → Hide
         #
-        # 2. WRAP BY VECTOR FILTER FAILURE (Critical Limitation)
-        #    ParaView's "Wrap by Vector" filter (for mesh deformation visualization)
+        # 2. WARP BY VECTOR FILTER FAILURE (Critical Limitation)
+        #    ParaView's "Warp by Vector" filter (for mesh deformation visualization)
         #    FAILS or BEHAVES INCORRECTLY when multiple vector fields are present.
         #    ROOT CAUSE: Filter input selection is ambiguous with composite metadata.
         #    WORKAROUND: Use individual field files instead:
@@ -170,7 +170,7 @@ class SaveFields:
         #    - Quick initial result verification
         #
         #    USE INDIVIDUAL FILES FOR:
-        #    - Mesh deformation visualization (Wrap by Vector) → u/u.xdmf
+        #    - Mesh deformation visualization (Warp by Vector) → u/u.xdmf
         #    - Field-specific analysis and filtering
         #    - Publication-quality visualizations
         #    - Large simulations (smaller file size per field)
@@ -212,7 +212,7 @@ class SaveFields:
             field.name = field_data["label_name"]
             self.output_fields[i].write_function(field, t)
             # Write to merged solution file for unified analysis across all fields.
-            # For specific field visualization (e.g., deformation via Wrap by Vector),
+            # For specific field visualization (e.g., deformation via Warp by Vector),
             # use individual field files in ParaView instead.
             self.merged_output.write_function(field, t)
 


### PR DESCRIPTION
Create merged solution file containing all fields

IMPORTANT: Known limitations and behaviors of this merged XDMF file:

1. VTK COMPOSITE METADATA (Artifacts)
   When multiple <Attribute> elements exist in the same XDMF <Grid>,
   VTK interprets this as a composite dataset and AUTOMATICALLY ADDS:
   - vtkCompositeIndex: Internal tracking field (not real data)
   - vtkBlockColors: Internal visualization field (not real data)
   These clutter the ParaView field list but are harmless. 

2. WRAP BY VECTOR FILTER FAILURE (Critical Limitation)
   ParaView's "Wrap by Vector" filter (for mesh deformation visualization)
   FAILS or BEHAVES INCORRECTLY when multiple vector fields are present.
   ROOT CAUSE: Filter input selection is ambiguous with composite metadata.
   WORKAROUND: Use individual field files instead:
   - output_folder/u/u.xdmf for displacement deformation.

3. XDMF STRUCTURE LIMITATION (DOLFINx API)
   DOLFINx's XDMFFile does not support external mesh references.
   Result: Mesh geometry/topology is DUPLICATED in this file.
   Workaround: None; inherent to DOLFINx API design.

4. USE CASES FOR MERGED vs INDIVIDUAL FILES

   USE MERGED (solution.xdmf) FOR:
   - Post-processing analysis across all fields simultaneously
   - Correlation studies between fields
   - Statistical analysis and data export
   - Quick initial result verification

   USE INDIVIDUAL FILES FOR:
   - Mesh deformation visualization (Wrap by Vector) → u/u.xdmf
   - Field-specific analysis and filtering
   - Publication-quality visualizations
   - Large simulations (smaller file size per field)