### PR TITLE
Include initial state to logging

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed dt display during simulations.
 - Implemented results logging at a specific point.
 - Fixed type hints in constitutive models.
+- Included initial state to results tracking.
 
 ## 3.0.3
 - Fixed mean stress calculation in P1P1 (mixed) formulation

--- a/safeincave/ScreenOutput.py
+++ b/safeincave/ScreenOutput.py
@@ -488,6 +488,28 @@ class ScreenPrinter:
             self.widths.append(len(header_column))
         self.divider = self.make_divider(self.widths, "+")
 
+    def print_initial_state(self, t: float, t_final: float, time_conversion: float) -> None:
+        """
+        Print the initial state row (step 0) to the progress table.
+
+        Parameters
+        ----------
+        t : float
+            Current time in seconds.
+        t_final : float
+            Final time in seconds.
+        time_conversion : float
+            Conversion factor from seconds to display unit.
+        """
+        current_time = "%.3f" % (t / time_conversion)
+        self.print_row([
+            0,
+            0.0,
+            f"{current_time} / {t_final / time_conversion}",
+            0,
+            0.0,
+        ])
+
     def print_header(self) -> None:
         """
         Print the top divider, a formatted header row, and a divider below.

--- a/safeincave/SimulationLogging.py
+++ b/safeincave/SimulationLogging.py
@@ -341,6 +341,42 @@ class SimulationLogging:
             import sys
             print(f"ERROR initializing log file {self._log_file}: {e}", file=sys.stderr)
     
+    def log_initial_state(
+        self,
+        time: float = 0.0,
+        time_final: float = 1.0,
+        stress: Optional[to.Tensor] = None,
+        strain: Optional[to.Tensor] = None,
+        **kwargs
+    ) -> None:
+        """
+        Log the initial state (step 0) with zero dt and zero iterations.
+
+        Parameters
+        ----------
+        time : float, optional
+            Initial time (raw, SI seconds). Default 0.0.
+        time_final : float, optional
+            Final time endpoint. Default 1.0.
+        stress : torch.Tensor, optional
+            Full stress tensor, shape (N, 3, 3).
+        strain : torch.Tensor, optional
+            Total strain tensor, shape (N, 3, 3).
+        **kwargs : dict
+            Additional variables for extractors.
+        """
+        self.log_step(
+            step=0,
+            time=time,
+            time_step=0.0,
+            time_final=time_final,
+            iteration=-1,          # displays as Iters=0
+            nonlinear_error=0.0,
+            stress=stress,
+            strain=strain,
+            **kwargs
+        )
+
     def log_step(
         self,
         step: int,

--- a/safeincave/Simulators.py
+++ b/safeincave/Simulators.py
@@ -367,9 +367,24 @@ class Simulator_TM(Simulator):
         for output in self.outputs:
             output.save_fields(0)
 
+        # Log initial state (step 0) to simulation logger
+        if self.simulation_logger is not None:
+            self.simulation_logger.log_initial_state(
+                time=self.t_control.t,
+                time_final=self.t_control.t_final,
+                stress=stress_to,
+                strain=eps_tot_to,
+            )
+
+        # Print initial state header row
+        self.screen.print_initial_state(
+            self.t_control.t,
+            self.t_control.t_final,
+            self.t_control.time_conversion,
+        )
+
         # First step has no previous nonlinear iteration count.
         ite = 0
-        ite_for_advance = 0
 
         # Time loop
         while self.t_control.keep_looping():
@@ -381,11 +396,8 @@ class Simulator_TM(Simulator):
                 step_state = self._capture_step_state(include_heat=True, include_caverns=True)
                 stress_to_step_start = stress_to.clone()
 
-                # Advance time. If adaptive, it need to send the iteration number
-                try:
-                    self.t_control.advance_time(ite_for_advance)
-                except (NameError, TypeError):      ##NameError = first iteration, ite not defined. TypeError: time control not a function of ite
-                    self.t_control.advance_time()
+                # Advance time
+                self.t_control.advance_time()
 
                 t = self.t_control.t
                 dt = self.t_control.dt
@@ -469,7 +481,7 @@ class Simulator_TM(Simulator):
                     n_bisections += 1
                     continue
 
-                # Relative-iteration adaptive dt integration (Task #5/#9).
+                # Adaptive dt integration via relative convergence ratio.
                 if hasattr(self.t_control, "get_next_dt"):
                     maxiter = max(int(self.convergence_handler.maxiter or 1), 1)
                     convergence_ratio = ite / maxiter
@@ -478,11 +490,6 @@ class Simulator_TM(Simulator):
                         n_bisections=n_bisections,
                         converged=True,
                     )
-                    # Avoid double-adaptation by legacy absolute-iteration path.
-                    ite_for_advance = 0
-                else:
-                    # Legacy controllers continue to adapt with absolute ite.
-                    ite_for_advance = ite
 
                 # Calculate next cavern masses and volumes
                 self.caverns.calculate_initial_conditions()
@@ -690,9 +697,26 @@ class Simulator_M(Simulator):
         for output in self.outputs:
             output.save_fields(0)
 
+        # Log initial state (step 0) to simulation logger
+        if self.simulation_logger is not None:
+            log_kwargs = SimulationLogging.extract_yield_variables(self.eq_mom.mat)
+            self.simulation_logger.log_initial_state(
+                time=self.t_control.t,
+                time_final=self.t_control.t_final,
+                stress=stress_to,
+                strain=eps_tot_to,
+                **log_kwargs
+            )
+
+        # Print initial state header row
+        self.screen.print_initial_state(
+            self.t_control.t,
+            self.t_control.t_final,
+            self.t_control.time_conversion,
+        )
+
         # First step has no previous nonlinear iteration count.
         ite = 0
-        ite_for_advance = 0
 
         # Time loop
         while self.t_control.keep_looping():
@@ -704,11 +728,8 @@ class Simulator_M(Simulator):
                 step_state = self._capture_step_state(include_heat=False, include_caverns=True)
                 stress_to_step_start = stress_to.clone()
 
-                # Advance time. If adaptive, it need to send the iteration number
-                try:
-                    self.t_control.advance_time(ite_for_advance)
-                except (NameError, TypeError):      ##NameError = first iteration, ite not defined. TypeError: time control not a function of ite
-                    self.t_control.advance_time()
+                # Advance time
+                self.t_control.advance_time()
 
                 t = self.t_control.t
                 dt = self.t_control.dt
@@ -777,11 +798,10 @@ class Simulator_M(Simulator):
                     stress_to = stress_to_step_start.clone()
                     dt_floor = float(getattr(self.t_control, "dt_min", 0.0))
                     self.t_control.dt = max(step_state["time"]["dt"] * 0.5, dt_floor)
-                    ite_for_advance = 0
                     n_bisections += 1
                     continue
 
-                # Relative-iteration adaptive dt integration (Task #5/#9).
+                # Adaptive dt integration via relative convergence ratio.
                 if hasattr(self.t_control, "get_next_dt"):
                     maxiter = max(int(self.convergence_handler.maxiter or 1), 1)
                     convergence_ratio = ite / maxiter
@@ -790,11 +810,6 @@ class Simulator_M(Simulator):
                         n_bisections=n_bisections,
                         converged=True,
                     )
-                    # Avoid double-adaptation by legacy absolute-iteration path.
-                    ite_for_advance = 0
-                else:
-                    # Legacy controllers continue to adapt with absolute ite.
-                    ite_for_advance = ite
 
                 # Calculate next cavern masses and volumes
                 self.caverns.calculate_initial_conditions()
@@ -945,17 +960,28 @@ class Simulator_T(Simulator):
         # Save fields
         output.save_fields(0)
 
+        # Log initial state (step 0) to simulation logger
+        if self.simulation_logger is not None:
+            self.simulation_logger.log_initial_state(
+                time=self.t_control.t,
+                time_final=self.t_control.t_final,
+            )
+
+        # Print initial state header row
+        self.screen.print_initial_state(
+            self.t_control.t,
+            self.t_control.t_final,
+            self.t_control.time_conversion,
+        )
+
         # Thermal-only solver has no nonlinear mechanical iterations.
         ite = 0
 
         # Time loop
         while self.t_control.keep_looping():
 
-            # Advance time. If adaptive, it need to send the iteration number
-            try:
-                self.t_control.advance_time(ite)
-            except (NameError, TypeError):      ##NameError = first iteration, ite not defined. TypeError: time control not a function of ite
-                self.t_control.advance_time()
+            # Advance time
+            self.t_control.advance_time()
 
             t = self.t_control.t
             dt = self.t_control.dt
@@ -1126,9 +1152,24 @@ class Simulator_Mout(Simulator):
         self.eq_mom.compute_q_nodes()
         output.save_fields(0)
 
+        # Log initial state (step 0) to simulation logger
+        if self.simulation_logger is not None:
+            self.simulation_logger.log_initial_state(
+                time=self.t_control.t,
+                time_final=self.t_control.t_final,
+                stress=stress_to,
+                strain=eps_tot_to,
+            )
+
+        # Print initial state header row
+        self.screen.print_initial_state(
+            self.t_control.t,
+            self.t_control.t_final,
+            self.t_control.time_conversion,
+        )
+
         # First step has no previous nonlinear iteration count.
         ite = 0
-        ite_for_advance = 0
 
         # Time loop
         while self.t_control.keep_looping():
@@ -1140,11 +1181,8 @@ class Simulator_Mout(Simulator):
                 step_state = self._capture_step_state(include_heat=False, include_caverns=False)
                 stress_to_step_start = stress_to.clone()
 
-                # Advance time. If adaptive, it need to send the iteration number
-                try:
-                    self.t_control.advance_time(ite_for_advance)
-                except (NameError, TypeError):      ##NameError = first iteration, ite not defined. TypeError: time control not a function of ite
-                    self.t_control.advance_time()
+                # Advance time
+                self.t_control.advance_time()
 
                 t = self.t_control.t
                 dt = self.t_control.dt
@@ -1201,11 +1239,10 @@ class Simulator_Mout(Simulator):
                     stress_to = stress_to_step_start.clone()
                     dt_floor = float(getattr(self.t_control, "dt_min", 0.0))
                     self.t_control.dt = max(step_state["time"]["dt"] * 0.5, dt_floor)
-                    ite_for_advance = 0
                     n_bisections += 1
                     continue
 
-                # Relative-iteration adaptive dt integration (Task #5/#9).
+                # Adaptive dt integration via relative convergence ratio.
                 if hasattr(self.t_control, "get_next_dt"):
                     maxiter = max(int(self.convergence_handler.maxiter or 1), 1)
                     convergence_ratio = ite / maxiter
@@ -1214,11 +1251,6 @@ class Simulator_Mout(Simulator):
                         n_bisections=n_bisections,
                         converged=True,
                     )
-                    # Avoid double-adaptation by legacy absolute-iteration path.
-                    ite_for_advance = 0
-                else:
-                    # Legacy controllers continue to adapt with absolute ite.
-                    ite_for_advance = ite
 
                 # Update internal variables
                 self.eq_mom.update_internal_variables()

--- a/safeincave/Simulators.py
+++ b/safeincave/Simulators.py
@@ -973,9 +973,6 @@ class Simulator_T(Simulator):
             self.t_control.time_conversion,
         )
 
-        # Thermal-only solver has no nonlinear mechanical iterations.
-        ite = 0
-
         # Time loop
         while self.t_control.keep_looping():
 

--- a/safeincave/Simulators.py
+++ b/safeincave/Simulators.py
@@ -477,7 +477,6 @@ class Simulator_TM(Simulator):
                     stress_to = stress_to_step_start.clone()
                     dt_floor = float(getattr(self.t_control, "dt_min", 0.0))
                     self.t_control.dt = max(step_state["time"]["dt"] * 0.5, dt_floor)
-                    ite_for_advance = 0
                     n_bisections += 1
                     continue
 

--- a/safeincave/TimeHandler.py
+++ b/safeincave/TimeHandler.py
@@ -176,29 +176,24 @@ class TimeControllerAdaptive(TimeControllerBase):
     """
     Adaptive-step time controller.
 
-    Supports two adaptation interfaces:
-    1) Legacy absolute-iteration adaptation via `advance_time(numberIterations)`.
-    2) Relative-iteration adaptation via `get_next_dt(convergence_ratio, ...)`.
-
-    Legacy behavior is preserved for backward compatibility.
+    Uses the relative-convergence interface via `get_next_dt(convergence_ratio, ...)`
+    to decide dt growth or shrinkage based on the ratio of solver iterations
+    to the maximum allowed iterations.
 
     Parameters
     ----------
-    initial_dt : float
-    Initial time-step size expressed in the units given by `time_unit`.
-    max_dt : float
-    Maximum time-step size expressed in the units given by `time_unit`.
     initial_time : float
     Start time expressed in the units given by `time_unit`.
+    initial_dt : float
+    Initial time-step size expressed in the units given by `time_unit`.
     final_time : float
     Final time expressed in the units given by `time_unit`.
-    time_unit : {"second", "minute", "hour", "day", "year"}, default="second"
-    Unit used to interpret `dt`, `initial_time`, and `final_time`.
-
-    dt_min : float, optional
+    time_unit : {"second", "minute", "hour", "day", "year"}, default="hour"
+    Unit used to interpret all time-related parameters.
+    dt_min : float, default=0.001
     Minimum time-step size expressed in the units given by `time_unit`.
-    dt_max : float, optional
-    Alias for `max_dt` to support a clearer API.
+    dt_max : float, default=1
+    Maximum time-step size expressed in the units given by `time_unit`.
     growth_factor : float, default=1.5
     Multiplicative factor for dt growth in easy-convergence regions.
     shrink_factor : float, default=0.5
@@ -224,13 +219,10 @@ class TimeControllerAdaptive(TimeControllerBase):
         initial_dt: float,
         final_time: float,
         time_unit: str = "hour",
-        iterations_min: int = 5,
-        iterations_max: int = 10,
-        inflation: float = 2.0,
-        dt_max: float = 1,
         dt_min: float = 0.001,
-        growth_factor: float = 1.5,
+        dt_max: float = 1,
         shrink_factor: float = 0.5,
+        growth_factor: float = 1.5,
         easy_ratio_threshold: float = 0.25,
         hard_ratio_threshold: float = 0.50,
         max_bisections: int = 5,
@@ -245,11 +237,6 @@ class TimeControllerAdaptive(TimeControllerBase):
         self.dt_max = dt_max * self.time_conversion
 
         self.flag_functionOfIteration = True
-
-        # Legacy absolute-iteration controls
-        self.iterations_min = iterations_min
-        self.iterations_max = iterations_max
-        self.inflation = inflation
 
         # Relative-iteration controls
         self.growth_factor = growth_factor
@@ -323,22 +310,14 @@ class TimeControllerAdaptive(TimeControllerBase):
         self.last_dt_reason = reason
         return self._clamp_dt(dt_candidate)
 
-    def advance_time(self, numberIterations: int = 0) -> None:
+    def advance_time(self) -> None:
         """
-        Increment the current time by a `dt` that changes as a function of the number of iterations.
+        Increment the current time by `dt`.
 
         Returns
         -------
         None
         """
-
-        if self.step_counter != 0 and numberIterations != 0:
-            if numberIterations <= self.iterations_min:
-                self.dt *= self.inflation
-            elif numberIterations >= self.iterations_max:
-                self.dt /= self.inflation
-
-        self.dt = self._clamp_dt(self.dt)
 
         remaining_time = self.t_final - self.t
         if remaining_time <= 0.0:


### PR DESCRIPTION
initial state was missing from simulationlogging and resulting log.csv file...knowing the initial state t=0 is often important, e.g. to subtract strains from initial convergence. this has been included here and in screenoutput for consistency. 
additional patch: removed legacy functionality from adaptive time step, since new functionality is basically an update of it.

```
Step,dt (h),t/t_final,Iters,NL_Error,sxx (Pa),syy (Pa),szz (Pa),exx (-),eyy (-),ezz (-)
0,0.0,0.0,0,0.0,-3999999.9999889294,-4000000.000002834,-4100000.000001457,-1.5392153720743773e-05,-1.539215372092098e-05,-1.6666663327780815e-05
1,0.5,0.020833333333333332,4,4.253135141252069e-15,-4000000.000012164,-4000000.0000065602,-7074999.999999626,-8.066245681662925e-05,-8.066245681626603e-05,-0.00027997581484809597
2,0.75,0.052083333333333336,5,4.428469922528294e-10,-3999999.9999996303,-4000000.000010068,-11537499.999999687,-1.0958622721811114e-05,-1.0958622722264058e-05,-0.0008124285192889746
3,1.125,0.09895833333333333,13,5.983874290924941e-08,-4000000.1428068145,-3999999.823658619,-16000000.014360841,0.0015076583377522134,0.0015076583823411351,-0.00271516929202069
4,1.125,0.14583333333333334,5,5.816097224901525e-09,-4000001.3663132014,-3999997.5399452723,-16000000.640261387,0.0033765302197010377,0.003376530681977976,-0.004801884990954259
5,1.6875,0.21614583333333334,5,1.3052372832082752e-08,-4000006.296028673,-3999992.1352180587,-16000001.668038072,0.004669900964657159,0.004669903023219957,-0.005993193962069497
6,2.53125,0.3216145833333333,5,4.580288119189653e-09,-4000005.711398761,-3999992.6526840245,-16000001.556166975,0.0057433300685157404,0.0057433329902904316,-0.007066099245792303
7,3.796875,0.4798177083333333,5,5.623508759602309e-09,-4000004.066222836,-3999995.258065225,-16000001.02838178,0.006767334406402628,0.006767336821921863,-0.008016864571867005
8,5.6953125,0.7171223958333334,4,5.932245343946033e-09,-3999996.363157158,-3999992.9434070583,-6000000.4213381745,0.007045671956860567,0.0070456739789745955,-0.007633190784267434
9,6.7890625,1.0,4,4.287311274376576e-10,-3999997.8814111985,-3999993.0291575002,-6000000.233015791,0.0069738788816280945,0.006973880869856277,-0.007418791287370149
```