### PR TITLE
closing solve for consistent inelastic state commit

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Option for smoothed output functionality.
 - Fixed broken von Mises extractor in SimulationLogging (raised AttributeError) and reduced logging setup verbosity.
 - Implemented local extensions mechanism.
+- Added a closing solve per time step so the committed inelastic strain uses the final converged rate (fixes hardening drift on models with persistent internal variables); constitutive models can now opt in to an exact elastic-trial reconstruction via uses_exact_trial.
 
 ## 3.0.3
 - Fixed mean stress calculation in P1P1 (mixed) formulation

--- a/safeincave/MomentumEquation.py
+++ b/safeincave/MomentumEquation.py
@@ -380,7 +380,9 @@ class LinearMomentumBase(ABC):
             eps_ne_k += elem_ne.eps_ne_k
         return eps_ne_k
 
-    def compute_eps_ne_rate(self, stress: to.Tensor, dt: float) -> None:
+    def compute_eps_ne_rate(
+        self, stress: to.Tensor, dt: float, eps_tot: to.Tensor | None = None
+    ) -> None:
         """
         Update non-elastic strain rate for all non-elastic elements.
 
@@ -390,14 +392,28 @@ class LinearMomentumBase(ABC):
             Stress per element, shape ``(n_elems, 3, 3)``.
         dt : float
             Time-step size.
+        eps_tot : torch.Tensor, optional
+            Current-iteration total strain, shape ``(n_elems, 3, 3)``. Passed
+            through (with the matching thermal strain) only to elements that
+            opt in via ``uses_exact_trial = True``, letting them reconstruct
+            the elastic trial stress directly from this iteration's strain
+            and the start-of-step committed inelastic strain -- avoiding the
+            one-iteration staleness of reconstructing it from a stored rate.
 
         Returns
         -------
         None
         """
+        eps_th = None
         for elem_ne in self.mat.elems_ne:
+            kwargs = {}
+            if eps_tot is not None and getattr(elem_ne, "uses_exact_trial", False):
+                if eps_th is None:
+                    eps_th = self.compute_eps_th()
+                kwargs["eps_tot"] = eps_tot
+                kwargs["eps_th"] = eps_th
             elem_ne.compute_eps_ne_rate(
-                stress, dt * self.theta, self.Temp, return_eps_ne=False
+                stress, dt * self.theta, self.Temp, return_eps_ne=False, **kwargs
             )
 
     def update_eps_ne_rate_old(self) -> None:

--- a/safeincave/Simulators.py
+++ b/safeincave/Simulators.py
@@ -35,6 +35,37 @@ class Simulator(ABC):
         """
         pass
 
+    def _final_consuming_solve(self, stress_to, t: float, dt: float):
+        """
+        Advance eps_ne_k with the converged inelastic rate before committing.
+
+        The nonlinear loop's order is solve -> stress -> compute_eps_ne_rate,
+        so the rate computed in the final iteration is never pushed into eps_ne_k
+        before update_eps_ne_old commits it. This call advances eps_ne_k without
+        resolving the momentum equation (displacement is already converged).
+
+        Note: does NOT call increment_internal_variables again here — the main
+        loop's last iteration already incremented hardening variables (e.g.
+        ViscoplasticDesai.alpha) using self.r/self.h/self.P linearized at that
+        iteration's stress. Calling it again here reapplies that same stale
+        linearization against a second, different stress delta, double-counting
+        the hardening update every step. Harmless for models without persistent
+        hardening state via this hook, but on models that have it
+        (ViscoplasticDesai, MunsonDawsonCreep, ModifiedCamClayViscoplastic) it
+        drove alpha to drift until compute_CT's consistent tangent went singular.
+        """
+        # Commit the plain (un-relaxed) rate, not the over-relaxed iterate.
+        for elem_ne in getattr(self.eq_mom.mat, "elems_ne", []):
+            fn = getattr(elem_ne, "finalize_step_rate", None)
+            if callable(fn):
+                fn()
+        # Advance eps_ne_k with the final converged rate, then update stress.
+        stress_k_to = stress_to.clone()
+        self.eq_mom.compute_eps_ne_k(dt)
+        eps_tot_to = self.eq_mom.compute_total_strain()
+        stress_to = self.eq_mom.compute_stress(eps_tot_to)
+        return stress_to, stress_k_to, eps_tot_to
+
     def _compute_error(self) -> float:
         """
         Compute current raw convergence error.
@@ -452,7 +483,7 @@ class Simulator_TM(Simulator):
                     self.eq_mom.increment_internal_variables(stress_to, stress_k_to, dt)
 
                     # Compute inelastic strain rates
-                    self.eq_mom.compute_eps_ne_rate(stress_to, dt)
+                    self.eq_mom.compute_eps_ne_rate(stress_to, dt, eps_tot_to)
 
                     # Recalculate volumes of caverns
                     self.caverns.calculate_volumes(self.eq_mom.u)
@@ -464,6 +495,7 @@ class Simulator_TM(Simulator):
 
                 ite = self.convergence_handler.ite
                 converged = not self.convergence_handler.not_converged_error
+                retry_scale = 0.5
 
                 if not converged:
                     if n_bisections >= max_bisections:
@@ -478,9 +510,17 @@ class Simulator_TM(Simulator):
                     )
                     stress_to = stress_to_step_start.clone()
                     dt_floor = float(getattr(self.t_control, "dt_min", 0.0))
-                    self.t_control.dt = max(step_state["time"]["dt"] * 0.5, dt_floor)
+                    self.t_control.dt = max(
+                        step_state["time"]["dt"] * retry_scale, dt_floor
+                    )
                     n_bisections += 1
                     continue
+
+                # Closing solve: consume the final iteration's inelastic rate
+                # so the committed internal state matches the converged rate.
+                stress_to, stress_k_to, eps_tot_to = self._final_consuming_solve(
+                    stress_to, t, dt
+                )
 
                 # Adaptive dt integration via relative convergence ratio.
                 if hasattr(self.t_control, "get_next_dt"):
@@ -770,7 +810,7 @@ class Simulator_M(Simulator):
                     self.eq_mom.increment_internal_variables(stress_to, stress_k_to, dt)
 
                     # Compute inelastic strain rates
-                    self.eq_mom.compute_eps_ne_rate(stress_to, dt)
+                    self.eq_mom.compute_eps_ne_rate(stress_to, dt, eps_tot_to)
 
                     # Recalculate volumes of caverns
                     self.caverns.calculate_volumes(self.eq_mom.u)
@@ -782,6 +822,7 @@ class Simulator_M(Simulator):
 
                 ite = self.convergence_handler.ite
                 converged = not self.convergence_handler.not_converged_error
+                retry_scale = 0.5
 
                 if not converged:
                     if n_bisections >= max_bisections:
@@ -796,9 +837,17 @@ class Simulator_M(Simulator):
                     )
                     stress_to = stress_to_step_start.clone()
                     dt_floor = float(getattr(self.t_control, "dt_min", 0.0))
-                    self.t_control.dt = max(step_state["time"]["dt"] * 0.5, dt_floor)
+                    self.t_control.dt = max(
+                        step_state["time"]["dt"] * retry_scale, dt_floor
+                    )
                     n_bisections += 1
                     continue
+
+                # Closing solve: consume the final iteration's inelastic rate
+                # so the committed internal state matches the converged rate.
+                stress_to, stress_k_to, eps_tot_to = self._final_consuming_solve(
+                    stress_to, t, dt
+                )
 
                 # Adaptive dt integration via relative convergence ratio.
                 if hasattr(self.t_control, "get_next_dt"):
@@ -1211,7 +1260,7 @@ class Simulator_Mout(Simulator):
                     self.eq_mom.increment_internal_variables(stress_to, stress_k_to, dt)
 
                     # Compute inelastic strain rates
-                    self.eq_mom.compute_eps_ne_rate(stress_to, dt)
+                    self.eq_mom.compute_eps_ne_rate(stress_to, dt, eps_tot_to)
 
                     # Compute error via active convergence criterion
                     self.convergence_handler.evaluate(self.eq_mom)
@@ -1220,6 +1269,7 @@ class Simulator_Mout(Simulator):
 
                 ite = self.convergence_handler.ite
                 converged = not self.convergence_handler.not_converged_error
+                retry_scale = 0.5
 
                 if not converged:
                     if n_bisections >= max_bisections:
@@ -1234,9 +1284,17 @@ class Simulator_Mout(Simulator):
                     )
                     stress_to = stress_to_step_start.clone()
                     dt_floor = float(getattr(self.t_control, "dt_min", 0.0))
-                    self.t_control.dt = max(step_state["time"]["dt"] * 0.5, dt_floor)
+                    self.t_control.dt = max(
+                        step_state["time"]["dt"] * retry_scale, dt_floor
+                    )
                     n_bisections += 1
                     continue
+
+                # Closing solve: consume the final iteration's inelastic rate
+                # so the committed internal state matches the converged rate.
+                stress_to, stress_k_to, eps_tot_to = self._final_consuming_solve(
+                    stress_to, t, dt
+                )
 
                 # Adaptive dt integration via relative convergence ratio.
                 if hasattr(self.t_control, "get_next_dt"):


### PR DESCRIPTION
The nonlinear loop's order is solve -> stress -> compute_eps_ne_rate, so the rate computed in the final iteration was never pushed into eps_ne_k before update_eps_ne_old committed it. A closing solve per accepted step now advances eps_ne_k with the converged rate (without re-solving the momentum equation) and lets elements commit a plain rate via an optional finalize_step_rate() hook. Constitutive models can also opt in to an exact elastic-trial reconstruction with uses_exact_trial = True, receiving eps_tot/eps_th in compute_eps_ne_rate. Retry shrink factor factored into retry_scale.