### PR TITLE
GitHub actions caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ jobs:
     name: SafeInCave tests
     runs-on: ubuntu-22.04
 
+    env:
+      CONDA_PKGS_DIRS: ${{ github.workspace }}/.conda_pkgs_dir
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -39,6 +42,14 @@ jobs:
           sudo apt-get install --yes --no-install-recommends \
             libgl1 \
             libglu1-mesa
+
+      - name: Cache conda packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CONDA_PKGS_DIRS }}
+          key: conda-pkgs-${{ runner.os }}-${{ hashFiles('.github/workflows/tests.yml') }}
+          restore-keys: |
+            conda-pkgs-${{ runner.os }}-
 
       - name: Set up Python with FEniCSx 0.9.0
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,14 @@ jobs:
               )
           PY
 
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('.github/workflows/tests.yml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+
       - name: Install Python package and test dependencies
         shell: bash -el {0}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install pinned FEniCSx
         shell: bash -el {0}
         run: |
-          mamba install --yes \
+          conda install --yes \
             fenics-dolfinx=0.9.0 \
             numpy=1.26.4 \
             scipy=1.14.1 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      CONDA_PKGS_DIRS: ${{ github.workspace }}/.conda_pkgs_dir
+      CONDA_PKGS_DIRS: ${{ runner.temp }}/conda_pkgs_dir
 
     steps:
       - name: Check out repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install pinned FEniCSx
         shell: bash -el {0}
         run: |
-          conda install --yes \
+          mamba install --yes \
             fenics-dolfinx=0.9.0 \
             numpy=1.26.4 \
             scipy=1.14.1 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,6 @@ jobs:
     name: SafeInCave tests
     runs-on: ubuntu-22.04
 
-    env:
-      CONDA_PKGS_DIRS: ${{ runner.temp }}/conda_pkgs_dir
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -42,6 +39,9 @@ jobs:
           sudo apt-get install --yes --no-install-recommends \
             libgl1 \
             libglu1-mesa
+
+      - name: Set conda packages cache directory
+        run: echo "CONDA_PKGS_DIRS=$RUNNER_TEMP/conda_pkgs_dir" >> "$GITHUB_ENV"
 
       - name: Cache conda packages
         uses: actions/cache@v4

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Updated readme with HyCavern and lined rock cavern info.
 - Pinned dependency versions exactly and removed unused packages to prevent CI churn.
 - Bumped CI to Python 3.12 to match the project's conda envs and fix an unsolvable conda-forge dependency pin.
+- Speed up CI test workflow.
 
 ## 3.0.3
 - Fixed mean stress calculation in P1P1 (mixed) formulation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Updated readme with HyCavern and lined rock cavern info.
 - Pinned dependency versions exactly and removed unused packages to prevent CI churn.
 - Bumped CI to Python 3.12 to match the project's conda envs and fix an unsolvable conda-forge dependency pin.
-- Speed up CI test workflow.
+- Caching in CI test workflow.
 
 ## 3.0.3
 - Fixed mean stress calculation in P1P1 (mixed) formulation


### PR DESCRIPTION
Dependency caching is standard practice — virtually every major CI system (GitHub Actions, GitLab CI, CircleCI) documents it as a first recommendation, and it's essentially free: no behavior change, low risk, doesn't affect what gets installed, just avoids re-downloading it. 

The Tests CI workflow spent ~83% of its ~2-minute runtime rebuilding the Python/conda environment from scratch on every single run (no caching existed at all), while the actual 46-test suite ran in ~8s. Two caching layers were added:

- Conda package cache — persists the downloaded fenics-dolfinx/PETSc/MPI/HDF5 packages between runs instead of re-fetching ~1GB from conda-forge every time.

- Pip download cache — persists downloaded wheels (notably the torch CPU wheel) between runs.

| Step | Baseline (no caching) | With caching |
|---|---|---|
| **Total wall time** | **~2m0s-2m10s** | **~1m45s-2m1s** |