### PR TITLE
included cli functionality

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Pinned dependency versions exactly and removed unused packages to prevent CI churn.
 - Bumped CI to Python 3.12 to match the project's conda envs and fix an unsolvable conda-forge dependency pin.
 - Caching in CI test workflow.
+- Add sic CLI subcommand.
 
 ## 3.0.3
 - Fixed mean stress calculation in P1P1 (mixed) formulation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dependencies = [
   "scipy==1.14.1",
 ]
 
+[project.scripts]
+sic = "safeincave.cli:main"
+
 [project.optional-dependencies]
 docs = [
   "mkdocs",

--- a/safeincave/cli.py
+++ b/safeincave/cli.py
@@ -1,0 +1,64 @@
+"""Command-line entry point for the ``sic`` command.
+
+Built-in subcommands are registered directly below. External packages can
+contribute additional subcommands (e.g. ``safeincave_viewer``'s ``view``
+command) without owning the ``sic`` console_script themselves, by declaring
+an entry point in the ``sic.commands`` group:
+
+    [project.entry-points."sic.commands"]
+    view = "some_package.cli:register"
+
+where ``register(subparsers)`` adds its own ``argparse`` subparser, the same
+way the built-in ``run`` command does below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import warnings
+from importlib.metadata import entry_points
+from pathlib import Path
+
+
+def _run_script(args: argparse.Namespace) -> None:
+    script_path = Path.cwd() / f"{args.name}.py"
+    if not script_path.is_file():
+        print(f"sic run: no such file: {script_path}", file=sys.stderr)
+        sys.exit(1)
+
+    result = subprocess.run([sys.executable, str(script_path), *args.script_args])
+    sys.exit(result.returncode)
+
+
+def _register_run(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("run", help="Run <name>.py from the current directory (default: main)")
+    parser.add_argument(
+        "name",
+        nargs="?",
+        default="main",
+        help="Script name without the .py extension (default: 'main')",
+    )
+    parser.add_argument("script_args", nargs=argparse.REMAINDER, help="Extra arguments forwarded to the script")
+    parser.set_defaults(func=_run_script)
+
+
+def _load_plugin_commands(subparsers: argparse._SubParsersAction) -> None:
+    for entry_point in entry_points(group="sic.commands"):
+        try:
+            register = entry_point.load()
+            register(subparsers)
+        except Exception as exc:  # noqa: BLE001 - a broken plugin must not break `sic`
+            warnings.warn(f"Failed to load sic plugin command '{entry_point.name}': {exc}", RuntimeWarning)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="sic", description="SafeInCave command-line tools")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    _register_run(subparsers)
+    _load_plugin_commands(subparsers)
+
+    args = parser.parse_args(sys.argv[1:])
+    args.func(args)

--- a/safeincave/cli.py
+++ b/safeincave/cli.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 
 def _run_script(args: argparse.Namespace) -> None:
-    script_path = Path.cwd() / f"{args.name}.py"
+    script_path = Path.cwd() / args.name
     if not script_path.is_file():
         print(f"sic run: no such file: {script_path}", file=sys.stderr)
         sys.exit(1)
@@ -33,12 +33,12 @@ def _run_script(args: argparse.Namespace) -> None:
 
 
 def _register_run(subparsers: argparse._SubParsersAction) -> None:
-    parser = subparsers.add_parser("run", help="Run <name>.py from the current directory (default: main)")
+    parser = subparsers.add_parser("run", help="Run <name>.py from the current directory (default: main.py)")
     parser.add_argument(
         "name",
         nargs="?",
-        default="main",
-        help="Script name without the .py extension (default: 'main')",
+        default="main.py",
+        help="Script filename, including the .py extension (default: 'main.py')",
     )
     parser.add_argument("script_args", nargs=argparse.REMAINDER, help="Extra arguments forwarded to the script")
     parser.set_defaults(func=_run_script)


### PR DESCRIPTION
- Adds a sic command-line tool to the safeincave package, registered via [project.scripts] in pyproject.toml.

- Implements sic run [name] (safeincave/cli.py), which runs <name>.py (default: main.py) from the current working directory via the active Python interpreter, forwards any extra arguments to the script, and propagates its exit code.

- Adds a sic.commands entry-point group so external packages can register additional sic subcommands (e.g. a mesh/results viewer) without owning the sic console script themselves — broken plugins warn instead of breaking the base CLI.

Running example/simulation scripts currently means cd-ing into a directory and invoking python main.py by hand. sic run standardizes that into a single command name, and the plugin mechanism lets add-on packages extend sic independently of this repo's release cycle.
