### PR TITLE
Add generic Newton momentum solver, yield tracking, and Mandel/quadra…

### DIFF
--- a/safeincave/Equations/Momentum/__init__.py
+++ b/safeincave/Equations/Momentum/__init__.py
@@ -7,5 +7,6 @@
 from .base import LinearMomentumBase  # noqa: F401
 from .standard import LinearMomentum  # noqa: F401
 from .mixed import LinearMomentumMixed  # noqa: F401
+from .momentum_newton_solver import MomentumNewtonSolver  # noqa: F401
 
-__all__ = ["LinearMomentumBase", "LinearMomentum", "LinearMomentumMixed"]
+__all__ = ["LinearMomentumBase", "LinearMomentum", "LinearMomentumMixed", "MomentumNewtonSolver"]

--- a/safeincave/Equations/Momentum/momentum_newton_solver.py
+++ b/safeincave/Equations/Momentum/momentum_newton_solver.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, The SafeInCave Developers
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Newton-step solver for momentum equations: assembles and solves one correction
+via K·δu = -R (preonly + LU factorization).
+
+Adapted from the dolfinx-external-operator tutorial's ``solvers.py``
+(MIT, A. Latyshev & J. Hale).
+
+Generic dolfinx/PETSc plumbing with no dependency on any particular solver
+backend (JAX, torch, ...) — shared by any Newton-type momentum solve.
+"""
+
+from __future__ import annotations
+
+import ufl
+from petsc4py import PETSc
+
+from dolfinx import fem
+
+
+class MomentumNewtonSolver:
+    """Assemble-and-solve one Newton correction step for momentum equations.
+    
+    Solves the linearized system K·δu = -R where:
+    - K is the Jacobian of the residual (dR)
+    - R is the momentum residual
+    - u is the current displacement iterate
+    - δu is the correction increment
+    
+    Uses PETSc KSP with preonly+LU (MUMPS when available).
+    """
+
+    def __init__(self, dR: ufl.Form, R: ufl.Form, u: fem.Function, bcs=None):
+        """Initialize Newton solver for one momentum correction.
+        
+        Parameters
+        ----------
+        dR : ufl.Form
+            Jacobian form (derivative of residual w.r.t. displacement).
+        R : ufl.Form
+            Momentum residual form.
+        u : fem.Function
+            Current displacement iterate (used for BC lifting).
+        bcs : list[DirichletBC], optional
+            Boundary conditions (default: none).
+        """
+        self.u = u
+        self.bcs = bcs or []
+        self.b_form = fem.form(R)
+        self.A_form = fem.form(dR)
+        self.b = fem.petsc.create_vector(self.b_form)
+        self.A = fem.petsc.create_matrix(self.A_form)
+        self.comm = u.function_space.mesh.comm
+        self.solver = PETSc.KSP().create(self.comm)
+        self.solver.setType("preonly")
+        self.solver.getPC().setType("lu")
+        # MUMPS factorizes noticeably faster than PETSc's built-in serial LU
+        # on the quadrature-space P2 systems this solver assembles (see
+        # FullNewtonRaphsonSolver's LinearMomentumNewton, which sets the same
+        # option). Falls back to the default factorizer on PETSc builds
+        # without MUMPS.
+        try:
+            self.solver.getPC().setFactorSolverType("mumps")
+        except Exception:
+            pass  # PETSc build without MUMPS: default LU is fine
+        self.solver.setOperators(self.A)
+
+    def assemble_vector(self) -> None:
+        """
+        Assemble the Newton right-hand side with BC lifting relative to the
+        current iterate ``u`` (the step increment): after the correction,
+        BC dofs of ``u`` equal the (possibly inhomogeneous) BC values and
+        subsequent corrections there vanish.
+        """
+        with self.b.localForm() as b_local:
+            b_local.set(0.0)
+        fem.petsc.assemble_vector(self.b, self.b_form)
+        fem.petsc.apply_lifting(
+            self.b, [self.A_form], [self.bcs], x0=[self.u.x.petsc_vec], alpha=1.0
+        )
+        self.b.ghostUpdate(addv=PETSc.InsertMode.ADD, mode=PETSc.ScatterMode.REVERSE)
+        fem.petsc.set_bc(self.b, self.bcs, x0=self.u.x.petsc_vec, alpha=1.0)
+
+    def assemble_matrix(self) -> None:
+        """Assemble the Newton Jacobian matrix (system matrix K)."""
+        self.A.zeroEntries()
+        fem.petsc.assemble_matrix(self.A, self.A_form, bcs=self.bcs)
+        self.A.assemble()
+
+    def solve(self, du: fem.Function) -> None:
+        """Solve K·δu = -R for the correction increment du."""
+        self.solver.solve(self.b, du.x.petsc_vec)
+
+    def __del__(self):
+        self.solver.destroy()
+        self.A.destroy()
+        self.b.destroy()

--- a/safeincave/Output/__init__.py
+++ b/safeincave/Output/__init__.py
@@ -10,6 +10,11 @@ from .SimLogging import (
     get_variable,
     list_registered_variables,
 )
+from .field_utils import _QuadratureView  # noqa: F401
+from .yield_tracking import (  # noqa: F401
+    register_generic_yield,
+    register_yield_surface,
+)
 
 __all__ = [
     "SaveFields",
@@ -18,4 +23,7 @@ __all__ = [
     "register_variable",
     "get_variable",
     "list_registered_variables",
+    "_QuadratureView",
+    "register_generic_yield",
+    "register_yield_surface",
 ]

--- a/safeincave/Output/field_utils.py
+++ b/safeincave/Output/field_utils.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, The SafeInCave Developers
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Quadrature-space view helper shared by dolfinx-based output classes
+(e.g. the autodiff/JAX external-operator solver path's ``SaveFields``
+and ``PointLogger``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from dolfinx import fem
+
+
+class _QuadratureView:
+    """Cell-wise view of a quadrature-space Function via its dofmap."""
+
+    def __init__(self, fn: fem.Function, n_comp: int):
+        self.fn = fn
+        self.n_comp = n_comp
+        self.dm = fn.function_space.dofmap.list  # (n_cells, n_qp)
+        self.n_cells, self.n_qp = self.dm.shape
+
+    def cell_values(self) -> np.ndarray:
+        """(n_cells, n_qp, n_comp) array of the current values."""
+        flat = self.fn.x.array.reshape(-1, self.n_comp)
+        return flat[self.dm]
+
+    def cell_mean(self) -> np.ndarray:
+        """(n_cells, n_comp) quadrature-point average per cell."""
+        return self.cell_values().mean(axis=1)

--- a/safeincave/Output/yield_tracking.py
+++ b/safeincave/Output/yield_tracking.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, The SafeInCave Developers
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Generic yield tracking for multi-mechanism plasticity models.
+
+Registers a configurable ``Yield`` variable in
+:mod:`safeincave.Output.SimLogging`'s variable registry: indicates whether
+any active yield surface (Drucker-Prager, Mohr-Coulomb, Rankine, etc.) is
+active, regardless of which one.
+
+Usage:
+    Import this module to activate generic yield tracking:
+    >>> from safeincave.Output import register_generic_yield
+    >>> register_generic_yield()
+
+    Then log ``"Yield"`` via :class:`safeincave.Output.SimulationLogging`.
+"""
+
+from __future__ import annotations
+
+from safeincave.Output import register_variable
+
+# Global registry of known yield surface variable names
+_REGISTERED_YIELD_SURFACES = {"yield_indicator", "yield_indicator_h"}
+
+
+def register_yield_surface(name: str) -> None:
+    """Register a custom yield surface name for auto-detection."""
+    _REGISTERED_YIELD_SURFACES.add(name.lower())
+
+
+def _extract_generic_yield(elem_id: int, **kwargs) -> int:
+    """Auto-detect yield from any registered surface."""
+    yielding = 0
+    # Check all registered yield surfaces
+    for surface_name in _REGISTERED_YIELD_SURFACES:
+        indicator = kwargs.get(surface_name)
+        if indicator is not None and int(indicator[elem_id].item()):
+            yielding = 1
+            break
+    return yielding
+
+
+def register_generic_yield() -> None:
+    """Register the generic 'Yield' variable in SimulationLogging."""
+    register_variable("Yield", "Yield", _extract_generic_yield)
+
+
+# Auto-register on import for backward compatibility
+register_generic_yield()

--- a/safeincave/Utils/__init__.py
+++ b/safeincave/Utils/__init__.py
@@ -5,3 +5,4 @@
 # Backward-compatible shim; actual implementation in Utils.IO
 from .IO import *  # noqa: F401, F403
 from .MeshParameter import Element, ModelML  # noqa: F401
+from .mandel import mandel_to_tensor3x3, p_q_from_mandel, principal_from_tensor  # noqa: F401

--- a/safeincave/Utils/mandel.py
+++ b/safeincave/Utils/mandel.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, The SafeInCave Developers
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Plain-NumPy Mandel-vector post-processing helpers shared by dolfinx-based
+output classes — distinct from any JAX-traced, differentiable math consumed
+directly inside a return-mapping solve.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+SQRT2 = np.sqrt(2.0)
+
+
+def mandel_to_tensor3x3(v: np.ndarray) -> np.ndarray:
+    """Batched Mandel vector(s) (N, 4|6) -> full tensors (N, 3, 3).
+
+    4-component vectors are plane strain: [xx, yy, zz, sqrt2*xy].
+    """
+    v = np.atleast_2d(v)
+    n, dim = v.shape
+    T = np.zeros((n, 3, 3))
+    T[:, 0, 0] = v[:, 0]
+    T[:, 1, 1] = v[:, 1]
+    T[:, 2, 2] = v[:, 2]
+    T[:, 0, 1] = T[:, 1, 0] = v[:, 3] / SQRT2
+    if dim == 6:
+        T[:, 0, 2] = T[:, 2, 0] = v[:, 4] / SQRT2
+        T[:, 1, 2] = T[:, 2, 1] = v[:, 5] / SQRT2
+    return T
+
+
+def p_q_from_mandel(v: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Mean stress (tr/3, signed) and von Mises stress from Mandel vectors."""
+    v = np.atleast_2d(v)
+    sm = (v[:, 0] + v[:, 1] + v[:, 2]) / 3.0
+    dev = v.copy()
+    dev[:, :3] -= sm[:, None]
+    # Mandel components carry the sqrt(2) factor: |dev|^2 is the tensor norm
+    q = np.sqrt(1.5 * np.sum(dev**2, axis=1))
+    return sm, q
+
+
+def principal_from_tensor(T: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Batched eigen-decomposition; eigenvalues descending (sig1 >= sig3)."""
+    w, V = np.linalg.eigh(T)
+    return w[:, ::-1], V[:, :, ::-1]


### PR DESCRIPTION
Adds reusable infrastructure for the Newton-based momentum solve path and output post-processing:

- MomentumNewtonSolver: backend-agnostic assemble/solve for one Newton correction step (K·δu = -R via PETSc preonly+LU, MUMPS when available).

- register_generic_yield() / register_yield_surface(): auto-detecting Yield output variable across any registered yield-surface indicator (Drucker-Prager, Mohr-Coulomb, Rankine, etc.).

- _QuadratureView: cell-wise view helper for quadrature-space Functions, used by output classes.

- mandel.py: NumPy helpers for Mandel-vector post-processing (tensor conversion, p-q invariants, principal values).

No behavior change to existing solvers; new modules are additive and wired into their package __init__.py exports.